### PR TITLE
Update mongoid_session_store.gemspec

### DIFF
--- a/mongoid_session_store.gemspec
+++ b/mongoid_session_store.gemspec
@@ -9,5 +9,5 @@ Gem::Specification.new do |s|
   s.files = Dir["lib/**/*"] + ["MIT-LICENSE", "Rakefile", "README.rdoc"]
   
   s.add_dependency('rails', '>= 4.0.0')
-  s.add_dependency('mongoid', '~> 4.0.0.beta1')
+  s.add_dependency('mongoid', '>= 4.0.0')
 end


### PR DESCRIPTION
Require mongoid version `>= 4.0.0` instead of `~> 4.0.0`
